### PR TITLE
Remove direct sha3 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ resolver = "2"
 # franklin-crypto = {path = "../franklin-crypto", features = ["plonk", "multicore"]}
 franklin-crypto = {git = "https://github.com/matter-labs/franklin-crypto", branch = "dev", features = ["multicore"]}
 sha2 = "0.10"
-sha3 = "0.10"
 hex = "*"
 once_cell = "*"
 derivative = "*"

--- a/src/glue/pubdata_hasher/variable_length.rs
+++ b/src/glue/pubdata_hasher/variable_length.rs
@@ -4,6 +4,7 @@ use super::input::*;
 use crate::glue::optimizable_queue::FixedWidthEncodingGenericQueue;
 use crate::glue::pubdata_hasher::storage_write_data::ByteSerializable;
 use franklin_crypto::plonk::circuit::hashes_with_tables::keccak::gadgets::*;
+use zkevm_opcode_defs::sha3::{self, Digest};
 
 pub fn hash_pubdata_entry_point_variable_length<
     E: Engine,
@@ -124,7 +125,6 @@ pub fn hash_pubdata_inner<
     // we can precompute special case, which is empty input queue,
     // so we will hash 4x0 bytes
 
-    use sha3::Digest;
     let empty_input_hash = sha3::Keccak256::digest(&[0u8; 4]);
     let mut byte_array = [0u8; 32];
     byte_array.copy_from_slice(empty_input_hash.as_slice());

--- a/src/precompiles/keccak256.rs
+++ b/src/precompiles/keccak256.rs
@@ -85,7 +85,7 @@ use franklin_crypto::plonk::circuit::hashes_with_tables::keccak::gadgets::{
     Keccak256Gadget, KeccakState,
 };
 
-use sha3::Digest;
+use zkevm_opcode_defs::sha3::{self, Digest};
 
 type Keccak256InnerState = [u64; 25];
 


### PR DESCRIPTION
zkevm_opcode_defs properly pins sha3 it to a specific version. This is important because we rely on the internal representation used in the library, so even minor changes can break our code.

I'm not sure if v1.3.2 is the best branch for this.